### PR TITLE
Add support for creating junctions on Windows

### DIFF
--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -11,8 +11,10 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
+	junction "github.com/nyaosorg/go-windows-junction"
 	"github.com/spf13/cobra"
 )
 
@@ -83,12 +85,21 @@ func execInit() {
 	for src, dest := range links {
 		folderSrcPath := filepath.Join(paths.ConfigPath, src)
 		folderDestPath := filepath.Join(destXpuiPath, dest)
-		log.Println("Symlinking", folderSrcPath, "to", folderDestPath)
-		err = os.Symlink(folderSrcPath, folderDestPath)
-		if err != nil {
-			log.Fatalln(err.Error())
+		if runtime.GOOS == "windows" {
+			log.Println("Creating junction", folderSrcPath, "->", folderDestPath)
+			err := junction.Create(folderSrcPath, folderDestPath)
+			if err != nil {
+				log.Fatalf("Failed to create junction: %v", err)
+			}
+		} else {
+			log.Println("Creating symbolic link", folderSrcPath, "->", folderDestPath)
+			err := os.Symlink(folderSrcPath, folderDestPath)
+			if err != nil {
+				log.Fatalf("Error creating symbolic link: %v", err)
+			}
 		}
 	}
+
 }
 
 func init() {

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -85,18 +85,23 @@ func execInit() {
 	for src, dest := range links {
 		folderSrcPath := filepath.Join(paths.ConfigPath, src)
 		folderDestPath := filepath.Join(destXpuiPath, dest)
+
+		linkType := "symbolic link"
 		if runtime.GOOS == "windows" {
-			log.Println("Creating junction", folderSrcPath, "->", folderDestPath)
-			err := junction.Create(folderSrcPath, folderDestPath)
-			if err != nil {
-				log.Fatalf("Failed to create junction: %v", err)
-			}
+			linkType = "junction"
+		}
+
+		log.Printf("Creating %s %s -> %s", linkType, folderSrcPath, folderDestPath)
+
+		var err error
+		if runtime.GOOS == "windows" {
+			err = junction.Create(folderSrcPath, folderDestPath)
 		} else {
-			log.Println("Creating symbolic link", folderSrcPath, "->", folderDestPath)
-			err := os.Symlink(folderSrcPath, folderDestPath)
-			if err != nil {
-				log.Fatalf("Error creating symbolic link: %v", err)
-			}
+			err = os.Symlink(folderSrcPath, folderDestPath)
+		}
+
+		if err != nil {
+			log.Fatalf("Error creating %s: %v", linkType, err)
 		}
 	}
 

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -86,12 +86,12 @@ func execInit() {
 		folderSrcPath := filepath.Join(paths.ConfigPath, src)
 		folderDestPath := filepath.Join(destXpuiPath, dest)
 
-		linkType := "symbolic link"
+		linkType := "Symlinking"
 		if runtime.GOOS == "windows" {
-			linkType = "junction"
+			linkType = "Junctioning"
 		}
 
-		log.Printf("Creating %s %s -> %s", linkType, folderSrcPath, folderDestPath)
+		log.Printf("%s %s to %s", linkType, folderSrcPath, folderDestPath)
 
 		var err error
 		if runtime.GOOS == "windows" {
@@ -101,7 +101,7 @@ func execInit() {
 		}
 
 		if err != nil {
-			log.Fatalf("Error creating %s: %v", linkType, err)
+			log.Fatalf("Error %s: %v", linkType, err)
 		}
 	}
 

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -93,7 +93,6 @@ func execInit() {
 
 		log.Printf("%s %s to %s", linkType, folderSrcPath, folderDestPath)
 
-		var err error
 		if runtime.GOOS == "windows" {
 			err = junction.Create(folderSrcPath, folderDestPath)
 		} else {
@@ -101,10 +100,9 @@ func execInit() {
 		}
 
 		if err != nil {
-			log.Fatalf("Error %s: %v", linkType, err)
+			log.Fatalln(err.Error())
 		}
 	}
-
 }
 
 func init() {


### PR DESCRIPTION
resolves #10 

![image](https://github.com/Delusoire/bespoke/assets/22730962/069d6551-777e-4ff4-85d9-3fc6f0b9cb83)

https://superuser.com/questions/343074/directory-junction-vs-directory-symbolic-link
i dont believe the fallbacks of junctions will be hurtful to our use case - but if you believe otherwise perhaps we can use them as a fallback instead, where we try to make a symlink and if it fails we ask the user if they want to exit and elevate or proceed with creating a junction instead.

optionally we could implement it as such (this just boils down to how you prefer the code to look):
```go
linkType := "Symlinking"
link := os.Symlink

if runtime.GOOS == "windows" {
    linkType = "Junctioning"
    link = junction.Create
}

log.Printf("%s %s to %s", linkType, folderSrcPath, folderDestPath)
err = link(folderSrcPath, folderDestPath)

```